### PR TITLE
Fixed permission error on Filebeat's Dockerfile

### DIFF
--- a/filebeat/Dockerfile
+++ b/filebeat/Dockerfile
@@ -1,8 +1,9 @@
 ARG ELK_VERSION
 
 FROM docker.elastic.co/beats/filebeat:${ELK_VERSION}
-COPY filebeat.yml /usr/share/filebeat/filebeat.yml
 USER root
+RUN chmod go-w filebeat.yml
+COPY filebeat.yml /usr/share/filebeat/filebeat.yml
 RUN mkdir /var/log/server
 RUN chown root:filebeat /usr/share/filebeat/filebeat.yml
 USER filebeat


### PR DESCRIPTION
ELK+Kafka 로그 시스템 구축 블로그 글 잘봤습니다.
예제 실행 도중 filebeat에 권한 이슈(owner만 쓰기권한을 가져야함)가 있어서 수정했습니다.